### PR TITLE
WIZ-3900 fix sorting

### DIFF
--- a/src/Repository/DiscussionRepository.php
+++ b/src/Repository/DiscussionRepository.php
@@ -167,7 +167,6 @@ class DiscussionRepository extends EntityManagerAware
             ->addSelect('Message')
             ->join('Discussion.messages', 'Message')
             ->orderBy('Message.send_date', 'DESC')
-            ->groupBy('Message.discussion')
         ;
 
         $this->andWhereDiscussionFilter($qb, $user_id, $status);


### PR DESCRIPTION
Correction du retour de test du 5/12/2019 sur le [ticket n°3900](https://wizaplace.atlassian.net/browse/WIZ-3900)
Le groupBy ne prend pas en compte le dernier message de la discussion en consequent le trie n'est pas correct.